### PR TITLE
Limit cropped screenshots by browser window's width

### DIFF
--- a/src/Selenium2Screenshots/keywords.robot
+++ b/src/Selenium2Screenshots/keywords.robot
@@ -565,8 +565,8 @@ Crop page screenshot
     ...        }
     ...        return [Math.max(0, left - ${CROP_MARGIN}),
     ...                Math.max(0, top - ${CROP_MARGIN}),
-    ...                Math.max(0, width + ${CROP_MARGIN} * 2),
-    ...                Math.max(height + ${CROP_MARGIN} * 2)];
+    ...                Math.min(window.outerWidth, width + ${CROP_MARGIN} * 2),
+    ...                height + ${CROP_MARGIN} * 2];
     ...    })();
     ${first} =  Convert to string  @{dimensions}[0]
     Should match regexp  ${first}  ^[\\d\\.]+$


### PR DESCRIPTION
The calculation of the dimensions for the cropped image can result in values, that exceed the source image. In those cases the result image will be expanded with transparent background. Due the nature, that "Capture Page Screenshot" varies in its width, it makes it very hard to produce identical screenshots - which is needed in our setup to determine visual regressions between cropped snapshots.

I therefor propose to limit the maximum width of the image by browser window's width.